### PR TITLE
claude/session-011CUZg5xXgZKB2nZdVcTJKf

### DIFF
--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -15,7 +15,9 @@ on:
 jobs:
   sync-dotfiles:
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: write  # Required to push commits
+
     steps:
       - name: Checkout justin-os
         uses: actions/checkout@v4


### PR DESCRIPTION
The workflow was failing with a 403 error because the default GITHUB_TOKEN didn't have explicit write permissions. This adds the required permissions to allow the workflow to push commits.

Fixes the error:
remote: Permission to zoro11031/justin-os.git denied to github-actions[bot]. fatal: unable to access 'https://github.com/zoro11031/justin-os/': The requested URL returned error: 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)