### PR TITLE
claude/session-011CUa2QqQuUu6tZwc3YNPDd

### DIFF
--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -95,9 +95,24 @@ jobs:
       - name: Create PR with changes
         if: steps.check_changes.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use GH_PAT if available (recommended), otherwise fall back to GITHUB_TOKEN
+          # Note: GITHUB_TOKEN requires "Allow GitHub Actions to create and approve pull requests"
+          # to be enabled in repository Settings → Actions → General
+          GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
         run: |
           set -eo pipefail
+
+          # Check if we're using a PAT or GITHUB_TOKEN
+          if [ -z "${{ secrets.GH_PAT }}" ]; then
+            echo "⚠️  Using default GITHUB_TOKEN (GH_PAT secret not configured)"
+            echo "If PR creation fails, you need to either:"
+            echo "  1. Add a GH_PAT secret with 'repo' or 'public_repo' scope, OR"
+            echo "  2. Enable 'Allow GitHub Actions to create and approve pull requests'"
+            echo "     in Settings → Actions → General"
+            echo ""
+          else
+            echo "✓ Using GH_PAT secret for authentication"
+          fi
 
           # Configure git
           git config user.name "github-actions[bot]"

--- a/README.md
+++ b/README.md
@@ -290,6 +290,28 @@ Follow the prompts and reboot to complete enrollment.
 
 See `docs/` folder for more troubleshooting guides.
 
+## Automated Dotfiles Sync
+
+This repository automatically syncs dotfiles from [zoro11031/dotfiles](https://github.com/zoro11031/dotfiles) daily and creates pull requests with any changes.
+
+**Setup Requirements:**
+
+To enable PR creation, you need to either:
+
+1. **Use a Personal Access Token (recommended):**
+   - Create a GitHub PAT with `repo` or `public_repo` scope
+   - Add it as a repository secret named `GH_PAT`
+   - Go to Settings → Secrets and variables → Actions → New repository secret
+
+2. **Enable GitHub Actions PR permission:**
+   - Go to Settings → Actions → General
+   - Enable "Allow GitHub Actions to create and approve pull requests"
+
+The workflow runs:
+- Daily at 2 AM UTC
+- Manually via workflow_dispatch
+- On webhook from dotfiles repo updates
+
 ## Documentation
 
 Additional documentation is available in the `docs/` folder:


### PR DESCRIPTION
This commit fixes the "GitHub Actions is not permitted to create or approve pull requests" error by implementing two solutions:

1. **Workflow Changes:**
   - Update sync-dotfiles workflow to use GH_PAT secret if available
   - Add fallback to GITHUB_TOKEN with clear documentation
   - Include runtime check that provides setup instructions if PR creation fails
   - Add helpful error messages explaining both setup options

2. **Documentation:**
   - Add "Automated Dotfiles Sync" section to README
   - Document two solutions: using a PAT or enabling repository setting
   - Explain when the workflow runs and setup requirements

The error occurs because GitHub has a repository-level security setting that prevents the default GITHUB_TOKEN from creating PRs. Users can now either:
- Add a GH_PAT secret (recommended for full automation)
- Enable "Allow GitHub Actions to create and approve pull requests" in repo settings

Relates to recent sync-dotfiles workflow improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)