### PR TITLE
Handle hidden directories during dotfiles sync

### DIFF
--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -36,46 +36,28 @@ jobs:
           
       - name: Copy updated configs
         run: |
-          # Copy zsh configs
-          if [ -f dotfiles-sync/zsh/.zshrc ]; then
-            cp dotfiles-sync/zsh/.zshrc files/home/.zshrc
-          fi
-          
-          if [ -f dotfiles-sync/zsh/.p10k.zsh ]; then
-            cp dotfiles-sync/zsh/.p10k.zsh files/home/.p10k.zsh
-          fi
-          
-          # Copy bash configs
-          if [ -f dotfiles-sync/bash/.bashrc ]; then
-            cp dotfiles-sync/bash/.bashrc files/home/.bashrc
-          fi
-          
-          # Copy ghostty config
-          if [ -f dotfiles-sync/ghostty/.config/ghostty/config ]; then
-            mkdir -p files/home/.config/ghostty
-            cp dotfiles-sync/ghostty/.config/ghostty/config files/home/.config/ghostty/config
-          fi
-          
-          # Copy neovim configs
-          if [ -d dotfiles-sync/nvim/.config/nvim ]; then
-            mkdir -p files/home/.config/nvim
-            # Use rsync to handle hidden files and empty directories
-            rsync -a dotfiles-sync/nvim/.config/nvim/ files/home/.config/nvim/
-          fi
-          
-          # Copy git configs
-          if [ -f dotfiles-sync/git/.gitconfig ]; then
-            cp dotfiles-sync/git/.gitconfig files/home/.gitconfig
-          fi
-          
-          # Copy tmux config
-          if [ -f dotfiles-sync/tmux/.tmux.conf ]; then
-            cp dotfiles-sync/tmux/.tmux.conf files/home/.tmux.conf
-          fi
-          
-          # Copy vim config
-          if [ -f dotfiles-sync/vim/.vimrc ]; then
-            cp dotfiles-sync/vim/.vimrc files/home/.vimrc
+          set -eo pipefail
+
+          mkdir -p files/home
+
+          copied_any=false
+
+          while IFS= read -r -d '' source; do
+            category="${source#dotfiles-sync/}"
+
+            case "$category" in
+              .git|.github)
+                continue
+                ;;
+            esac
+
+            echo "Syncing $category configs"
+            rsync -a "$source"/ files/home/
+            copied_any=true
+          done < <(find dotfiles-sync -mindepth 1 -maxdepth 1 -type d -print0)
+
+          if [ "$copied_any" = false ]; then
+            echo "No configuration directories found in dotfiles repository"
           fi
           
       - name: Check for changes

--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -53,6 +53,16 @@ jobs:
             fi
 
             if [ -d "$source" ]; then
+              if [[ "$category" == .* ]]; then
+                dest_prefix="$category"
+                rsync_dest="files/home/"
+                rsync_source="$source"
+              else
+                dest_prefix=""
+                rsync_dest="files/home/"
+                rsync_source="$source/"
+              fi
+
               echo "Syncing configs from $category"
 
               while IFS= read -r -d '' file; do
@@ -62,15 +72,21 @@ jobs:
                   continue
                 fi
 
-                if [[ -n "${seen_paths[$rel_path]}" ]]; then
-                  echo "Error: path '$rel_path' provided by '$category' also exists in '${seen_paths[$rel_path]}'" >&2
+                if [ -n "$dest_prefix" ]; then
+                  final_path="$dest_prefix/$rel_path"
+                else
+                  final_path="$rel_path"
+                fi
+
+                if [[ -n "${seen_paths[$final_path]}" ]]; then
+                  echo "Error: path '$final_path' provided by '$category' also exists in '${seen_paths[$final_path]}'" >&2
                   exit 1
                 fi
 
-                seen_paths[$rel_path]="$category"
+                seen_paths[$final_path]="$category"
               done < <(find "$source" -mindepth 1 \( -type f -o -type l \) -print0)
 
-              if output=$(rsync -a --itemize-changes "$source"/ files/home/); then
+              if output=$(rsync -a --itemize-changes "$rsync_source" "$rsync_dest"); then
                 if [ -n "$output" ]; then
                   echo "$output" | sed 's/^/  /'
                 else

--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -56,6 +56,7 @@ jobs:
               if [[ "$category" == .* ]]; then
                 dest_prefix="$category"
                 rsync_dest="files/home/"
+                # For dot-directories, omit trailing slash so rsync copies the directory itself (including its name) into the destination.
                 rsync_source="$source"
               else
                 dest_prefix=""

--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -86,12 +86,18 @@ jobs:
                 seen_paths[$final_path]="$category"
               done < <(find "$source" -mindepth 1 \( -type f -o -type l \) -print0)
 
-              if output=$(rsync -a --itemize-changes "$rsync_source" "$rsync_dest"); then
+              output=$(rsync -a --itemize-changes "$rsync_source" "$rsync_dest" 2>&1)
+              rsync_status=$?
+              if [ $rsync_status -eq 0 ]; then
                 if [ -n "$output" ]; then
                   echo "$output" | sed 's/^/  /'
                 else
                   echo "  No differences detected for $category"
                 fi
+              else
+                echo "Error syncing configs from $category:"
+                echo "$output" | sed 's/^/  /'
+                exit $rsync_status
               fi
 
             else

--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -40,24 +40,66 @@ jobs:
 
           mkdir -p files/home
 
+          shopt -s dotglob nullglob
+
           copied_any=false
+          declare -A seen_paths
 
           while IFS= read -r -d '' source; do
             category="${source#dotfiles-sync/}"
 
-            case "$category" in
-              .git|.github)
-                continue
-                ;;
-            esac
+            if [[ "$category" == ".git" || "$category" == ".github" ]]; then
+              continue
+            fi
 
-            echo "Syncing $category configs"
-            rsync -a "$source"/ files/home/
+            if [ -d "$source" ]; then
+              echo "Syncing configs from $category"
+
+              while IFS= read -r -d '' file; do
+                rel_path="${file#"$source"/}"
+
+                if [ -z "$rel_path" ]; then
+                  continue
+                fi
+
+                if [[ -n "${seen_paths[$rel_path]}" ]]; then
+                  echo "Error: path '$rel_path' provided by '$category' also exists in '${seen_paths[$rel_path]}'" >&2
+                  exit 1
+                fi
+
+                seen_paths[$rel_path]="$category"
+              done < <(find "$source" -mindepth 1 \( -type f -o -type l \) -print0)
+
+              if output=$(rsync -a --itemize-changes "$source"/ files/home/); then
+                if [ -n "$output" ]; then
+                  echo "$output" | sed 's/^/  /'
+                else
+                  echo "  No differences detected for $category"
+                fi
+              fi
+
+            else
+              rel_path="$category"
+
+              if [[ -n "${seen_paths[$rel_path]}" ]]; then
+                echo "Error: path '$rel_path' provided by 'dotfiles root' also exists in '${seen_paths[$rel_path]}'" >&2
+                exit 1
+              fi
+
+              seen_paths[$rel_path]="dotfiles root"
+
+              echo "Copying file $category"
+              dest_dir="files/home/$(dirname -- "$rel_path")"
+              dest_dir="${dest_dir%/.}"
+              mkdir -p "$dest_dir"
+              cp -a "$source" "files/home/$rel_path"
+            fi
+
             copied_any=true
-          done < <(find dotfiles-sync -mindepth 1 -maxdepth 1 -type d -print0)
+          done < <(find dotfiles-sync -mindepth 1 -maxdepth 1 ! -name '.git' ! -name '.github' -print0 | sort -z)
 
           if [ "$copied_any" = false ]; then
-            echo "No configuration directories found in dotfiles repository"
+            echo "No configuration entries found in dotfiles repository"
           fi
           
       - name: Check for changes

--- a/.github/workflows/sync-dotfiles.yml
+++ b/.github/workflows/sync-dotfiles.yml
@@ -106,6 +106,7 @@ jobs:
 
               echo "Copying file $category"
               dest_dir="files/home/$(dirname -- "$rel_path")"
+              # If dirname returns '.', this creates files/home/.; remove trailing '/.' to get files/home/
               dest_dir="${dest_dir%/.}"
               mkdir -p "$dest_dir"
               cp -a "$source" "files/home/$rel_path"


### PR DESCRIPTION
## Summary
- use find to iterate over configuration directories so hidden entries like .config are synchronized
- skip repository metadata directories such as .git and .github when copying configs

## Testing
- not run (workflow change)

------
https://chatgpt.com/codex/tasks/task_e_6902819e1c00832ea8f6ec2e2a715b55