### PR TITLE
Harden Microsoft key provisioning with embedded fallback

### DIFF
--- a/files/rpm-ostree/vscode.repo
+++ b/files/rpm-ostree/vscode.repo
@@ -4,4 +4,4 @@ name=Visual Studio Code
 baseurl=https://packages.microsoft.com/yumrepos/vscode
 enabled=1
 gpgcheck=1
-gpgkey=https://packages.microsoft.com/keys/microsoft.asc
+gpgkey=file:///etc/pki/rpm-gpg/MICROSOFT.asc

--- a/files/scripts/ensure-microsoft-gpg.sh
+++ b/files/scripts/ensure-microsoft-gpg.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+KEY_URL="https://packages.microsoft.com/keys/microsoft.asc"
+KEY_PATH="/etc/pki/rpm-gpg/MICROSOFT.asc"
+TMP_KEY="$(mktemp)"
+RETRIES="${MICROSOFT_KEY_RETRIES:-5}"
+SLEEP_SECONDS="${MICROSOFT_KEY_SLEEP_SECONDS:-5}"
+EXPECTED_FINGERPRINT="BC528686B50D79E339D3721CEB3E94ADBE1229CF"
+FALLBACK_TMP=""
+
+FALLBACK_KEY=$(cat <<'EOF'
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: BSN Pgp v1.1.0.0
+
+mQENBFYxWIwBCADAKoZhZlJxGNGWzqV+1OG1xiQeoowKhssGAKvd+buXCGISZJwT
+LXZqIcIiLP7pqdcZWtE9bSc7yBY2MalDp9Liu0KekywQ6VVX1T72NPf5Ev6x6DLV
+7aVWsCzUAF+eb7DC9fPuFLEdxmOEYoPjzrQ7cCnSV4JQxAqhU4T6OjbvRazGl3ag
+OeizPXmRljMtUUttHQZnRhtlzkmwIrUivbfFPD+fEoHJ1+uIdfOzZX8/oKHKLe2j
+H632kvsNzJFlROVvGLYAk2WRcLu+RjjggixhwiB+Mu/A8Tf4V6b+YppS44q8EvVr
+M+QvY7LNSOffSO6Slsy9oisGTdfE39nC7pVRABEBAAG0N01pY3Jvc29mdCAoUmVs
+ZWFzZSBzaWduaW5nKSA8Z3Bnc2VjdXJpdHlAbWljcm9zb2Z0LmNvbT6JATQEEwEI
+AB4FAlYxWIwCGwMGCwkIBwMCAxUIAwMWAgECHgECF4AACgkQ6z6Urb4SKc+P9gf/
+diY2900wvWEgV7iMgrtGzx79W/PbwWiOkKoD9sdzhARXWiP8Q5teL/t5TUH6TZ3B
+ENboDjwr705jLLPwuEDtPI9jz4kvdT86JwwG6N8gnWM8Ldi56SdJEtXrzwtlB/Fe
+6tyfMT1E/PrJfgALUG9MWTIJkc0GhRJoyPpGZ6YWSLGXnk4c0HltYKDFR7q4wtI8
+4cBu4mjZHZbxIO6r8Cci+xxuJkpOTIpr4pdpQKpECM6x5SaT2gVnscbN0PE19KK9
+nPsBxyK4wW0AvAhed2qldBPTipgzPhqB2gu0jSryil95bKrSmlYJd1Y1XfNHno5D
+xfn5JwgySBIdWWvtOI05gw==
+=zPfd
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+)
+
+cleanup() {
+  rm -f "$TMP_KEY"
+  if [[ -n "$FALLBACK_TMP" ]]; then
+    rm -f "$FALLBACK_TMP"
+  fi
+}
+trap cleanup EXIT
+
+fingerprint_for() {
+  local key_file="$1"
+  gpg --with-colons --show-keys "$key_file" | awk -F: '/^fpr:/ {print toupper($10); exit}'
+}
+
+install_key_from() {
+  local source_file="$1"
+  local fingerprint
+  fingerprint="$(fingerprint_for "$source_file")"
+
+  if [[ -z "$fingerprint" ]]; then
+    echo "Unable to read fingerprint from $source_file" >&2
+    return 1
+  fi
+
+  if [[ "$fingerprint" != "$EXPECTED_FINGERPRINT" ]]; then
+    echo "Unexpected Microsoft GPG fingerprint: $fingerprint" >&2
+    return 1
+  fi
+
+  install -Dm0644 "$source_file" "$KEY_PATH"
+  rpm --import "$KEY_PATH"
+}
+
+# Short key ID for Microsoft packages: EB3E94ADBE1229CF
+if rpm -qa gpg-pubkey | grep -qi 'eb3e94ad'; then
+  echo "Microsoft GPG key already installed; skipping download."
+  exit 0
+fi
+
+attempt=1
+while (( attempt <= RETRIES )); do
+  if curl -fsSL "$KEY_URL" -o "$TMP_KEY" && install_key_from "$TMP_KEY"; then
+    echo "Microsoft GPG key installed successfully."
+    exit 0
+  fi
+
+  echo "Attempt $attempt to download Microsoft GPG key failed." >&2
+  if (( attempt < RETRIES )); then
+    sleep "$SLEEP_SECONDS"
+  fi
+  ((attempt++))
+done
+echo "All download attempts failed; using embedded Microsoft GPG key fallback." >&2
+
+FALLBACK_TMP="$(mktemp)"
+printf '%s' "$FALLBACK_KEY" >"$FALLBACK_TMP"
+
+if install_key_from "$FALLBACK_TMP"; then
+  echo "Microsoft GPG key installed from embedded fallback." >&2
+  exit 0
+fi
+
+echo "ERROR: Embedded Microsoft GPG key did not match expected fingerprint." >&2
+exit 1

--- a/files/scripts/ensure-microsoft-gpg.sh
+++ b/files/scripts/ensure-microsoft-gpg.sh
@@ -51,10 +51,13 @@ fingerprint_for() {
   local key_file="$1"
   local gpg_output
 
-  if ! gpg_output="$(gpg --with-colons --show-keys "$key_file" 2>/dev/null)"; then
-    echo "gpg failed to inspect $key_file" >&2
+  if ! gpg_output_and_err="$(gpg --with-colons --show-keys "$key_file" 2>&1)"; then
+    echo "gpg failed to inspect $key_file (gpg may not be installed or file may be corrupted)" >&2
+    echo "gpg error output:" >&2
+    echo "$gpg_output_and_err" >&2
     return 1
   fi
+  gpg_output="$gpg_output_and_err"
 
   awk -F: '/^fpr:/ {print toupper($10); exit}' <<<"$gpg_output"
 }

--- a/files/scripts/ensure-microsoft-gpg.sh
+++ b/files/scripts/ensure-microsoft-gpg.sh
@@ -42,6 +42,9 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Returns the uppercase fingerprint for the given key file. A blank result
+# means gpg could not parse the file, indicating an invalid key payload or a
+# tooling failure upstream.
 fingerprint_for() {
   local key_file="$1"
   gpg --with-colons --show-keys "$key_file" | awk -F: '/^fpr:/ {print toupper($10); exit}'
@@ -58,6 +61,7 @@ ensure_key_file_matches() {
   fingerprint="$(fingerprint_for "$key_file")"
 
   if [[ -z "$fingerprint" ]]; then
+    echo "Unable to read fingerprint from $key_file" >&2
     return 1
   fi
 
@@ -125,5 +129,5 @@ if install_key_from "$FALLBACK_TMP"; then
   exit 0
 fi
 
-echo "ERROR: Embedded Microsoft GPG key did not match expected fingerprint." >&2
+echo "ERROR: Failed to install embedded Microsoft GPG key." >&2
 exit 1

--- a/files/scripts/ensure-microsoft-gpg.sh
+++ b/files/scripts/ensure-microsoft-gpg.sh
@@ -123,13 +123,16 @@ fi
 
 attempt=1
 while (( attempt <= RETRIES )); do
-  if curl --connect-timeout 10 --max-time 60 -fsSL "$KEY_URL" -o "$TMP_KEY" \
-      && install_key_from "$TMP_KEY"; then
-    echo "Microsoft GPG key installed successfully."
-    exit 0
+  if curl --connect-timeout 10 --max-time 60 -fsSL "$KEY_URL" -o "$TMP_KEY"; then
+    if install_key_from "$TMP_KEY"; then
+      echo "Microsoft GPG key installed successfully."
+      exit 0
+    else
+      echo "Attempt $attempt: Key validation failed for downloaded Microsoft GPG key." >&2
+    fi
+  else
+    echo "Attempt $attempt: Network failure while downloading Microsoft GPG key." >&2
   fi
-
-  echo "Attempt $attempt to download Microsoft GPG key failed." >&2
   if (( attempt < RETRIES )); then
     sleep "$SLEEP_SECONDS"
   fi

--- a/recipes/packages.yml
+++ b/recipes/packages.yml
@@ -1,9 +1,4 @@
 modules:
-  # Ensure the Microsoft GPG key is present before adding the repo
-  - type: script
-    scripts:
-      - ensure-microsoft-gpg.sh
-
   # Microsoft VS Code repository setup
   - type: rpm-ostree
     repos:

--- a/recipes/packages.yml
+++ b/recipes/packages.yml
@@ -1,10 +1,13 @@
 modules:
+  # Ensure the Microsoft GPG key is present before adding the repo
+  - type: script
+    scripts:
+      - ensure-microsoft-gpg.sh
+
   # Microsoft VS Code repository setup
   - type: rpm-ostree
     repos:
       - vscode.repo # stage local repo definition from files/rpm-ostree/vscode.repo
-    keys:
-      - https://packages.microsoft.com/keys/microsoft.asc
     install:
       - code
 

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -45,6 +45,11 @@ modules:
           - org.gnome.Loupe
       - scope: user
 
+  # Ensure the Microsoft GPG key is present before repo configuration
+  - type: script
+    scripts:
+      - ensure-microsoft-gpg.sh
+
   # Import consolidated modules
   - from-file: packages.yml
   - from-file: system-services.yml


### PR DESCRIPTION
## Summary
- embed the Microsoft RPM signing key directly in the provisioning script as a verified fallback
- validate downloaded and fallback keys against the expected fingerprint before importing
- fall back to the embedded key after retry exhaustion so builds continue without external connectivity

## Testing
- bash -n files/scripts/ensure-microsoft-gpg.sh

------
https://chatgpt.com/codex/tasks/task_e_69028c43bd88832e91089c658021bb9e