### PR TITLE
Consolidate shared font setup into include

### DIFF
--- a/recipes/recipe-surface.yml
+++ b/recipes/recipe-surface.yml
@@ -39,20 +39,8 @@ modules:
       - source: systemd/fix-vpn-selinux.service
         destination: /usr/lib/systemd/system/fix-vpn-selinux.service
 
-  # Microsoft fonts dependencies and installer
-  - type: rpm-ostree
-    install:
-      - curl
-      - cabextract
-      - xorg-x11-font-utils # Required by msttcore-fonts-installer
-      - fontconfig
-
-  # Install fonts and configure zsh (BEFORE changing /bin/sh)
-  - type: script
-    scripts:
-      - install-ms-fonts-build.sh
-      - install-nerd-fonts-build.sh
-      - set-default-shell-zsh.sh
+  # Shared Microsoft font installation and shell configuration sequence
+  - from-file: shared-fonts-shell.yml
 
   # Surface-specific packages
   - type: rpm-ostree

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -55,20 +55,8 @@ modules:
   - from-file: system-services.yml
   - from-file: common-flatpaks.yml
 
-  # Microsoft Core Fonts dependencies and installer
-  - type: rpm-ostree
-    install:
-      - curl
-      - cabextract
-      - xorg-x11-font-utils # Required by msttcore-fonts-installer
-      - fontconfig
-
-  # Configure shells and install fonts (BEFORE changing /bin/sh)
-  - type: script
-    scripts:
-      - install-ms-fonts-build.sh
-      - install-nerd-fonts-build.sh
-      - set-default-shell-zsh.sh
+  # Shared Microsoft font installation and shell configuration sequence
+  - from-file: shared-fonts-shell.yml
 
   - type: signing
 

--- a/recipes/shared-fonts-shell.yml
+++ b/recipes/shared-fonts-shell.yml
@@ -1,0 +1,15 @@
+modules:
+  # Microsoft Core Fonts dependencies and installer
+  - type: rpm-ostree
+    install:
+      - curl
+      - cabextract
+      - xorg-x11-font-utils # Required by msttcore-fonts-installer
+      - fontconfig
+
+  # Configure shells and install fonts (runs before /bin/sh is repointed)
+  - type: script
+    scripts:
+      - install-ms-fonts-build.sh
+      - install-nerd-fonts-build.sh
+      - set-default-shell-zsh.sh

--- a/recipes/shared-fonts-shell.yml
+++ b/recipes/shared-fonts-shell.yml
@@ -7,7 +7,7 @@ modules:
       - xorg-x11-font-utils # Required by msttcore-fonts-installer
       - fontconfig
 
-  # Configure shells and install fonts (runs before /bin/sh is repointed)
+  # Configure shells and install fonts (BEFORE changing /bin/sh)
   - type: script
     scripts:
       - install-ms-fonts-build.sh


### PR DESCRIPTION
## Summary
- extract the shared Microsoft font installation and shell configuration modules into `recipes/shared-fonts-shell.yml`
- reference the shared include from both image recipes so only variant-specific modules stay inline

## Testing
- bluebuild build recipes/recipe.yml *(fails: `bluebuild` not available in container)*
- bluebuild build recipes/recipe-surface.yml *(fails: `bluebuild` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69038e02bdc4832e95d5ce06621b5dc0