### PR TITLE
Add resilient RPM Fusion installer script

### DIFF
--- a/files/scripts/install-rpmfusion-release.sh
+++ b/files/scripts/install-rpmfusion-release.sh
@@ -41,7 +41,7 @@ download_with_retry() {
   local url
 
   for url in "$@"; do
-    if curl --retry "${RETRY_COUNT}" --retry-delay "${RETRY_DELAY}" -fL -o "${destination}" "${url}"; then
+    if curl --retry "${RETRY_COUNT}" --retry-delay "${RETRY_DELAY}" --connect-timeout 10 --max-time 60 -fL -o "${destination}" "${url}"; then
       return 0
     fi
     echo "Download failed for ${url}, trying next mirror if available..." >&2

--- a/files/scripts/install-rpmfusion-release.sh
+++ b/files/scripts/install-rpmfusion-release.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RETRY_COUNT="${RPMFUSION_RETRY_COUNT:-5}"
+RETRY_DELAY="${RPMFUSION_RETRY_DELAY:-10}"
+
+if rpm -q rpmfusion-free-release >/dev/null 2>&1 \
+  && rpm -q rpmfusion-nonfree-release >/dev/null 2>&1; then
+  echo "RPM Fusion release packages already installed; skipping download."
+  exit 0
+fi
+
+OS_VERSION="${OS_VERSION:-}"
+if [[ -z "${OS_VERSION}" ]]; then
+  if ! OS_VERSION="$(rpm -E %fedora)"; then
+    echo "Unable to determine Fedora version via rpm -E %fedora" >&2
+    exit 1
+  fi
+fi
+
+if [[ -z "${OS_VERSION}" ]]; then
+  echo "Fedora version is empty; cannot build RPM Fusion URLs" >&2
+  exit 1
+fi
+
+primary_free="https://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-%OS_VERSION%.noarch.rpm"
+primary_nonfree="https://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-%OS_VERSION%.noarch.rpm"
+fallback_free="https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-%OS_VERSION%.noarch.rpm"
+fallback_nonfree="https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-%OS_VERSION%.noarch.rpm"
+
+declare -A URLs=(
+  [free_primary]="${primary_free//%OS_VERSION%/${OS_VERSION}}"
+  [free_fallback]="${fallback_free//%OS_VERSION%/${OS_VERSION}}"
+  [nonfree_primary]="${primary_nonfree//%OS_VERSION%/${OS_VERSION}}"
+  [nonfree_fallback]="${fallback_nonfree//%OS_VERSION%/${OS_VERSION}}"
+)
+
+download_with_retry() {
+  local destination="$1"
+  shift
+  local url
+
+  for url in "$@"; do
+    if curl --retry "${RETRY_COUNT}" --retry-delay "${RETRY_DELAY}" -fL -o "${destination}" "${url}"; then
+      return 0
+    fi
+    echo "Download failed for ${url}, trying next mirror if available..." >&2
+  done
+
+  echo "All download attempts failed for ${destination}" >&2
+  return 1
+}
+
+TMPDIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${TMPDIR}"
+}
+trap cleanup EXIT
+
+FREE_RPM="${TMPDIR}/rpmfusion-free-release.rpm"
+NONFREE_RPM="${TMPDIR}/rpmfusion-nonfree-release.rpm"
+
+download_with_retry "${FREE_RPM}" "${URLs[free_primary]}" "${URLs[free_fallback]}"
+download_with_retry "${NONFREE_RPM}" "${URLs[nonfree_primary]}" "${URLs[nonfree_fallback]}"
+
+rpm-ostree install "${FREE_RPM}" "${NONFREE_RPM}"

--- a/files/scripts/install-rpmfusion-release.sh
+++ b/files/scripts/install-rpmfusion-release.sh
@@ -60,7 +60,13 @@ trap cleanup EXIT
 FREE_RPM="${TMP_WORKDIR}/rpmfusion-free-release.rpm"
 NONFREE_RPM="${TMP_WORKDIR}/rpmfusion-nonfree-release.rpm"
 
-download_with_retry "${FREE_RPM}" "${URLs[free_primary]}" "${URLs[free_fallback]}"
-download_with_retry "${NONFREE_RPM}" "${URLs[nonfree_primary]}" "${URLs[nonfree_fallback]}"
+if ! download_with_retry "${FREE_RPM}" "${URLs[free_primary]}" "${URLs[free_fallback]}"; then
+  echo "Failed to download RPM Fusion FREE repository release package." >&2
+  exit 1
+fi
 
+if ! download_with_retry "${NONFREE_RPM}" "${URLs[nonfree_primary]}" "${URLs[nonfree_fallback]}"; then
+  echo "Failed to download RPM Fusion NONFREE repository release package." >&2
+  exit 1
+fi
 rpm-ostree install "${FREE_RPM}" "${NONFREE_RPM}"

--- a/files/scripts/install-rpmfusion-release.sh
+++ b/files/scripts/install-rpmfusion-release.sh
@@ -51,14 +51,14 @@ download_with_retry() {
   return 1
 }
 
-TMPDIR="$(mktemp -d)"
+TMP_WORKDIR="$(mktemp -d)"
 cleanup() {
-  rm -rf "${TMPDIR}"
+  rm -rf "${TMP_WORKDIR}"
 }
 trap cleanup EXIT
 
-FREE_RPM="${TMPDIR}/rpmfusion-free-release.rpm"
-NONFREE_RPM="${TMPDIR}/rpmfusion-nonfree-release.rpm"
+FREE_RPM="${TMP_WORKDIR}/rpmfusion-free-release.rpm"
+NONFREE_RPM="${TMP_WORKDIR}/rpmfusion-nonfree-release.rpm"
 
 download_with_retry "${FREE_RPM}" "${URLs[free_primary]}" "${URLs[free_fallback]}"
 download_with_retry "${NONFREE_RPM}" "${URLs[nonfree_primary]}" "${URLs[nonfree_fallback]}"

--- a/recipes/recipe-surface.yml
+++ b/recipes/recipe-surface.yml
@@ -17,11 +17,10 @@ modules:
       - source: system
         destination: /
 
-  # Install RPM Fusion repositories
-  - type: rpm-ostree
-    install:
-      - https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-%OS_VERSION%.noarch.rpm
-      - https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-%OS_VERSION%.noarch.rpm
+  # Install RPM Fusion repositories with resilient mirror selection
+  - type: script
+    scripts:
+      - install-rpmfusion-release.sh
 
   # Import shared modules
   - from-file: packages-surface.yml

--- a/recipes/recipe.yml
+++ b/recipes/recipe.yml
@@ -20,11 +20,10 @@ modules:
       - source: system
         destination: / # System files and configurations
 
-  # Install RPM Fusion repositories
-  - type: rpm-ostree
-    install:
-      - https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-%OS_VERSION%.noarch.rpm
-      - https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-%OS_VERSION%.noarch.rpm
+  # Install RPM Fusion repositories with resilient mirror selection
+  - type: script
+    scripts:
+      - install-rpmfusion-release.sh
 
   # DNF packages
   - type: dnf


### PR DESCRIPTION
## Summary
- install the RPM Fusion release packages through a script that retries and falls back to an alternate mirror
- update the standard and Surface recipes to invoke the new installer so builds survive transient mirror outages

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_6903c2b296e8832ea280734020c4a41d