### PR TITLE
Remove reference to set-default-shell-zsh.sh script

### DIFF
--- a/recipes/shared-fonts-shell.yml
+++ b/recipes/shared-fonts-shell.yml
@@ -12,4 +12,3 @@ modules:
     scripts:
       - install-ms-fonts-build.sh
       - install-nerd-fonts-build.sh
-      - set-default-shell-zsh.sh


### PR DESCRIPTION
Removed the set-default-shell-zsh.sh script from the shared-fonts-shell recipe configuration as it is no longer needed.